### PR TITLE
Add some basic tests & unbreak async methods

### DIFF
--- a/lib/readPage.js
+++ b/lib/readPage.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var pify = require('pify')
 var smarkt = require('smarkt')
 var xtend = require('xtend')
 var path = require('path')
@@ -13,7 +14,7 @@ async function readPage (pathPage, opts) {
   assert.equal(typeof opts, 'object', 'arg2: opts must be type object')
   assert.equal(typeof opts.fs, 'object', 'arg2: opts.fs must be type object')
 
-  var fs = opts.fs
+  var fs = pify(opts.fs)
   var parse = typeof opts.parse === 'function' ? opts.parse : smarkt.parse
   var fileIndex = opts.file || defaults.file
   var fileExtname = path.extname(fileIndex)
@@ -25,7 +26,7 @@ async function readPage (pathPage, opts) {
   var childrenInput = await getChildren()
   var children = childrenInput
     .filter(file => utilFile.filterFile(file, fileIndex))
-    .reduce(utilFile.sortChildren, { files: [ ], pages: [ ] })
+    .reduce(utilFile.sortChildren, { files: [], pages: [] })
   var files = await getFiles(children.files)
   var pages = getPages(children.pages)
 
@@ -41,7 +42,7 @@ async function readPage (pathPage, opts) {
     try {
       return await fs.readdir(pathPage)
     } catch (err) {
-      return [ ]
+      return []
     }
   }
 
@@ -57,7 +58,7 @@ async function readPage (pathPage, opts) {
   }
 
   async function getFiles (files) {
-    var result = { }
+    var result = {}
     await Promise.all(files.map(read))
     return result
 
@@ -102,6 +103,6 @@ async function readPage (pathPage, opts) {
 
       if (fileParsed.name) result[fileParsed.name] = fileParsed
       return result
-    }, { })
+    }, {})
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "transform a directory of content into JSON",
   "main": "index.js",
   "scripts": {
-    "test": "standard --fix && node test.js | colortape"
+    "test": "standard --fix; ava"
   },
   "keywords": [],
   "author": "Jon-Kyle <contact@jon-kyle.com> (http://jon-kyle.com)",
@@ -22,6 +22,7 @@
     "js-yaml": "^3.10.0",
     "object-keys": "^1.0.11",
     "object-values": "^1.0.0",
+    "pify": "^3.0.0",
     "slash": "^1.0.0",
     "smarkt": "0.0.5",
     "static-module": "^1.5.0",
@@ -29,8 +30,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "colortape": "^0.1.2",
-    "standard": "^10.0.3",
-    "tape": "^4.8.0"
+    "ava": "^0.25.0",
+    "standard": "^10.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -15,9 +15,9 @@ test('readPage works', async function (t) {
 })
 
 test('readPageSync and readPage outputs are the same', async function (t) {
-  var sync = hypha.readPageSync('example/content/about')
-  var async = await hypha.readPage('example/content/about')
-  t.deepEqual(sync, async)
+  var syncPage = hypha.readPageSync('example/content/about')
+  var asyncPage = await hypha.readPage('example/content/about')
+  t.deepEqual(syncPage, asyncPage)
 })
 
 test('readSiteSync works', function (t) {
@@ -27,7 +27,7 @@ test('readSiteSync works', function (t) {
 })
 
 test('readSiteSync and readSite outputs are the same', async function (t) {
-  var sync = hypha.readSiteSync('example/content')
-  var async = await hypha.readSiteSync('example/content')
-  t.deepEqual(sync, async)
+  var syncSite = hypha.readSiteSync('example/content')
+  var asyncSite = await hypha.readSiteSync('example/content')
+  t.deepEqual(syncSite, asyncSite)
 })

--- a/test.js
+++ b/test.js
@@ -1,6 +1,33 @@
-var test = require('tape')
+var test = require('ava')
 
-test('placeholder', function (t) {
-  t.ok(true)
-  t.end()
+var hypha = require('.')
+
+test('readPageSync works', function (t) {
+  var page = hypha.readPageSync('example/content/about')
+  t.is(page.title, 'About')
+  t.is(page.view, 'custom')
+})
+
+test('readPage works', async function (t) {
+  var page = await hypha.readPage('example/content/about')
+  t.is(page.title, 'About')
+  t.is(page.view, 'custom')
+})
+
+test('readPageSync and readPage outputs are the same', async function (t) {
+  var sync = hypha.readPageSync('example/content/about')
+  var async = await hypha.readPage('example/content/about')
+  t.deepEqual(sync, async)
+})
+
+test('readSiteSync works', function (t) {
+  var site = hypha.readSiteSync('example/content')
+  t.is(site['/'].title, 'Example')
+  t.is(site['/about'].title, 'About')
+})
+
+test('readSiteSync and readSite outputs are the same', async function (t) {
+  var sync = hypha.readSiteSync('example/content')
+  var async = await hypha.readSiteSync('example/content')
+  t.deepEqual(sync, async)
 })


### PR DESCRIPTION
Hi Jon-Kyle, I was playing around with the library earlier and the async functions weren't working at all for me, so I dug in a bit & tried to fix them.

The root cause was that the calls to `fs` were using async/await, but they are all just callback-based functions. The fix is pretty simple - just promisify the fs module using [pify](https://npm.im/pify). Node 8 added a [util.promisify](https://nodejs.org/api/util.html#util_util_promisify_original) method, but with pify you can promisify the whole module at once, which was just more convenient - happy to change that if you prefer.

I added some basic tests which unfortunately revealed some further issues - the output from the sync/async methods is not the same, eg. one of the files is missing in the sync version, and there are some other small inconsistencies:

![image](https://user-images.githubusercontent.com/38614/36391910-89410c34-15a0-11e8-8064-e88cfc20a579.png)

I haven't fixed those other issues in this PR yet, because I just wanted to get things running on another project I'm working on, but happy to do some further work on this :)

I also changed the testing library from `tape` to [`ava`](https://github.com/avajs/ava), simply because it's much more ergonomic when async functions are involved - tape just craps out with useless "DeprecationWarning: Unhandled promise rejections are deprecated" messages - ava shows you what actually went wrong. Happy to change it back to tap if you're particularly attached to it.