### PR TITLE
fix async readSite

### DIFF
--- a/lib/readSite.js
+++ b/lib/readSite.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var path = require('path')
-var glob = require('glob')
+var pify = require('pify')
+var glob = pify(require('glob'))
 
 var readFiles = require('./readFiles')
 

--- a/test.js
+++ b/test.js
@@ -28,6 +28,6 @@ test('readSiteSync works', function (t) {
 
 test('readSiteSync and readSite outputs are the same', async function (t) {
   var syncSite = hypha.readSiteSync('example/content')
-  var asyncSite = await hypha.readSiteSync('example/content')
+  var asyncSite = await hypha.readSite('example/content')
   t.deepEqual(syncSite, asyncSite)
 })


### PR DESCRIPTION
There was a silly typo in the readSite tests, where the `readSiteSync` method was called both times.
When I finally wanted to use readSite for real, it still didn't work :~)
Fixed now.